### PR TITLE
Refactor: Pass Twilio client via Dependency Injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Pass Twilio client via Dependency Injection.
+
 ## 1.0.1
 * Restrict non-permited plugin files.
 * Update Twilio SDK package to 8.3.9.

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
     "lint": "vendor/bin/phpcs -v",
     "lint:fix": "vendor/bin/phpcbf -v",
     "test": "vendor/bin/phpunit --testdox",
-    "analyse": "vendor/bin/phpstan analyse --memory-limit=2048M"
+    "analyse": "vendor/bin/phpstan analyse --memory-limit=2048M",
+    "coverage": "XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-cobertura cobertura.xml && coveralls --repo-token=6418XFQj6GmHs5QeOUmI3pWSM0WMHppYH --file=cobertura.xml"
   }
 }

--- a/inc/Clients/Twilio.php
+++ b/inc/Clients/Twilio.php
@@ -2,8 +2,8 @@
 /**
  * Twilio class.
  *
- * This class acts as a wrapper around the Twilio REST
- * implementation for ease of use.
+ * This concrete class acts as a wrapper around the
+ * TwilioClient implementation.
  *
  * @package PendingOrderBot
  */
@@ -14,27 +14,6 @@ use PendingOrderBot\Interfaces\Client;
 use Twilio\Rest\Client as TwilioClient;
 
 class Twilio implements Client {
-	/**
-	 * Client Instance.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @var TwilioClient
-	 */
-	private TwilioClient $client;
-
-	/**
-	 * Set up.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $sid   Twilio Account SID.
-	 * @param string $token Twilio Token.
-	 */
-	public function __construct( $sid, $token ) {
-		$this->client = new TwilioClient( $sid, $token );
-	}
-
 	/**
 	 * Send Text Message.
 	 *
@@ -47,7 +26,7 @@ class Twilio implements Client {
 	 * @return void
 	 */
 	public function send( $from, $to, $message ): void {
-		$this->client->messages->create(
+		$this->get_twilio_client()->messages->create(
 			$to,
 			[
 				'from' => $from,
@@ -57,13 +36,16 @@ class Twilio implements Client {
 	}
 
 	/**
-	 * Get Client.
+	 * Set up.
 	 *
-	 * @since 1.0.0
+	 * @since 1.0.2
 	 *
-	 * @return Twilio
+	 * @return TwilioClient
 	 */
-	public function get_client(): TwilioClient {
-		return $this->client;
+	protected function get_twilio_client(): TwilioClient {
+		$sid   = pbot_get_settings( 'twilio_sid' );
+		$token = pbot_get_settings( 'twilio_token' );
+
+		return new TwilioClient( $sid, $token );
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -43,6 +43,9 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 == Changelog ==
 
+= Unreleased =
+* Pass Twilio client via Dependency Injection.
+
 = 1.0.1 =
 * Restrict non-permited plugin files.
 * Update Twilio SDK package to 8.3.9.

--- a/tests/Clients/TwilioTest.php
+++ b/tests/Clients/TwilioTest.php
@@ -9,9 +9,9 @@ use Twilio\Rest\Client as TwilioClient;
 use Twilio\Rest\Api\V2010\Account\MessageList as TwilioMessages;
 
 /**
- * @covers \PendingOrderBot\Clients\Twilio::__construct
- * @covers \PendingOrderBot\Clients\Twilio::get_client
+ * @covers \PendingOrderBot\Clients\Twilio::get_twilio_client
  * @covers \PendingOrderBot\Clients\Twilio::send
+ * @covers pbot_get_settings
  */
 class TwilioTest extends TestCase {
 	public Twilio $twilio;
@@ -19,30 +19,38 @@ class TwilioTest extends TestCase {
 	public function setUp(): void {
 		\WP_Mock::setUp();
 
-		$this->twilio = new Twilio( '1048892', 'a8g2lagjekied9' );
+		$this->twilio = new Twilio();
 	}
 
 	public function tearDown(): void {
 		\WP_Mock::tearDown();
 	}
 
-	public function test_client_is_instance_of_twilio() {
-		$this->assertInstanceOf( TwilioClient::class, $this->twilio->get_client() );
-	}
-
-	public function test_client_sends_text_message() {
-		$messages = Mockery::mock( TwilioMessages::class )->makePartial();
-		$messages->shouldAllowMockingProtectedMethods();
-
-		$client = Mockery::mock( TwilioClient::class )->makePartial();
-		$client->shouldAllowMockingProtectedMethods();
-		$client->messages = $messages;
-
+	public function test_get_twilio_client_returns_instance_of_twilio_client() {
 		$twilio = Mockery::mock( Twilio::class )->makePartial();
 		$twilio->shouldAllowMockingProtectedMethods();
-		$twilio->client = $client;
 
-		$messages->shouldReceive( 'create' )
+		\WP_Mock::userFunction( 'get_option' )
+			->times( 2 )
+			->with( 'pending_order_bot', [] )
+			->andReturn(
+				[
+					'twilio_sid'   => 1,
+					'twilio_token' => 'a8g2lagjekied9',
+				]
+			);
+
+		$this->assertInstanceOf( TwilioClient::class, $twilio->get_twilio_client() );
+	}
+
+	public function test_twilio_client_sends_text_message() {
+		$client = Mockery::mock( TwilioClient::class )->makePartial();
+		$client->shouldAllowMockingProtectedMethods();
+
+		$client->messages = Mockery::mock( TwilioMessages::class )->makePartial();
+		$client->messages->shouldAllowMockingProtectedMethods();
+
+		$client->messages->shouldReceive( 'create' )
 			->with(
 				'+1(234)567890',
 				[
@@ -51,13 +59,13 @@ class TwilioTest extends TestCase {
 				]
 			);
 
-		$twilio->client->messages->create(
-			'+1(234)567890',
-			[
-				'from' => 'john@doe.com',
-				'body' => 'You have abandoned cart orders.',
-			]
-		);
+		$twilio = Mockery::mock( Twilio::class )->makePartial();
+		$twilio->shouldAllowMockingProtectedMethods();
+
+		$twilio->shouldReceive( 'get_twilio_client' )
+			->andReturn( $client );
+
+		$twilio->send( 'john@doe.com', '+1(234)567890', 'You have abandoned cart orders.' );
 
 		$this->assertConditionsMet();
 	}

--- a/tests/Services/SchedulerTest.php
+++ b/tests/Services/SchedulerTest.php
@@ -4,14 +4,18 @@ namespace PendingOrderBot\Tests\Services;
 
 use Mockery;
 use WP_Mock\Tools\TestCase;
-use PendingOrderBot\Services\Scheduler;
+use PendingOrderBot\Clients\Twilio;
 use PendingOrderBot\Abstracts\Service;
+use PendingOrderBot\Services\Scheduler;
 
 /**
  * @covers \PendingOrderBot\Services\Scheduler::register
  * @covers \PendingOrderBot\Services\Scheduler::schedule_reminders
  * @covers \PendingOrderBot\Services\Scheduler::register_cron_schedules
  * @covers \PendingOrderBot\Services\Scheduler::get_pending_orders
+ * @covers \PendingOrderBot\Services\Scheduler::get_text_client
+ * @covers \PendingOrderBot\Services\Scheduler::send_reminders
+ * @covers pbot_get_settings
  */
 class SchedulerTest extends TestCase {
 	public Scheduler $scheduler;
@@ -99,13 +103,184 @@ class SchedulerTest extends TestCase {
 		$this->assertConditionsMet();
 	}
 
+	public function test_schedule_reminder_bails_if_woocommerce_is_not_active() {
+		$scheduler = Mockery::mock( Scheduler::class )->makePartial();
+		$scheduler->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( false );
+
+		$scheduler->send_reminders();
+
+		$this->assertConditionsMet();
+	}
+
+	public function test_schedule_reminder_catches_exception_and_applies_action() {
+		$scheduler = Mockery::mock( Scheduler::class )->makePartial();
+		$scheduler->shouldAllowMockingProtectedMethods();
+
+		$twilio = Mockery::mock( Twilio::class )->makePartial();
+		$twilio->shouldAllowMockingProtectedMethods();
+
+		$order = Mockery::mock( \WC_Order::class )->makePartial();
+		$order->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( true );
+
+		\WP_Mock::userFunction( 'get_option' )
+			->times( 2 )
+			->with( 'pending_order_bot', [] )
+			->andReturn(
+				[
+					'twilio_phone'   => '+1234567890',
+					'twilio_message' => 'You have abandoned cart orders.',
+				]
+			);
+
+		$order->shouldReceive( 'get_billing_phone' )
+			->andReturn( '+0987654321' );
+
+		$orders[] = $order;
+
+		$scheduler->shouldReceive( 'get_pending_orders' )
+			->andReturn( $orders );
+
+		$scheduler->shouldReceive( 'get_text_client' )
+			->andReturn( $twilio );
+
+		$twilio->shouldReceive( 'send' )
+			->with(
+				'+1234567890',
+				'+0987654321',
+				'You have abandoned cart orders.'
+			)
+			->andThrow(
+				new \Exception( 'SMS Text API is currently down...' )
+			);
+
+		\WP_Mock::expectAction(
+			'pbot_send_error',
+			'Error: Unable to send text message, SMS Text API is currently down...'
+		);
+
+		$scheduler->send_reminders();
+
+		$this->assertConditionsMet();
+	}
+
+	public function test_schedule_reminder_passes_correctly() {
+		$scheduler = Mockery::mock( Scheduler::class )->makePartial();
+		$scheduler->shouldAllowMockingProtectedMethods();
+
+		$twilio = Mockery::mock( Twilio::class )->makePartial();
+		$twilio->shouldAllowMockingProtectedMethods();
+
+		$order = Mockery::mock( \WC_Order::class )->makePartial();
+		$order->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( true );
+
+		\WP_Mock::userFunction( 'get_option' )
+			->times( 2 )
+			->with( 'pending_order_bot', [] )
+			->andReturn(
+				[
+					'twilio_phone'   => '+1234567890',
+					'twilio_message' => 'You have abandoned cart orders.',
+				]
+			);
+
+		$order->shouldReceive( 'get_billing_phone' )
+			->andReturn( '+0987654321' );
+
+		$orders[] = $order;
+
+		$scheduler->shouldReceive( 'get_pending_orders' )
+			->andReturn( $orders );
+
+		$scheduler->shouldReceive( 'get_text_client' )
+			->andReturn( $twilio );
+
+		$twilio->shouldReceive( 'send' )
+			->with(
+				'+1234567890',
+				'+0987654321',
+				'You have abandoned cart orders.'
+			)
+			->andReturn( null );
+
+		$scheduler->send_reminders();
+
+		$this->assertConditionsMet();
+	}
+
 	public function test_get_pending_orders_returns_empty_array() {
 		$scheduler = Mockery::mock( Scheduler::class )->makePartial();
 		$scheduler->shouldAllowMockingProtectedMethods();
 
+		\WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( false );
+
 		$orders = $scheduler->get_pending_orders();
 
 		$this->assertSame( $orders, [] );
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_pending_orders_returns_pending_orders() {
+		$scheduler = Mockery::mock( Scheduler::class )->makePartial();
+		$scheduler->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::userFunction( 'is_plugin_active' )
+			->once()
+			->with( 'woocommerce/woocommerce.php' )
+			->andReturn( true );
+
+		$order = Mockery::mock( \WC_Order::class )->makePartial();
+
+		$order->ID          = 1;
+		$order->post_type   = 'product';
+		$order->post_status = 'pending';
+
+		$orders[] = $order;
+
+		\WP_Mock::userFunction( 'wc_get_orders' )
+			->with(
+				[
+					'limit'  => -1,
+					'status' => 'pending',
+				]
+			)
+			->andReturn( $orders );
+
+		$response = $scheduler->get_pending_orders();
+
+		$this->assertSame( count( $response ), 1 );
+		$this->assertConditionsMet();
+	}
+
+	public function test_get_text_client_returns_twilio_client() {
+		$scheduler = Mockery::mock( Scheduler::class )->makePartial();
+		$scheduler->shouldAllowMockingProtectedMethods();
+
+		$twilio = Mockery::mock( Twilio::class )->makePartial();
+		$twilio->shouldAllowMockingProtectedMethods();
+
+		\WP_Mock::expectFilter( 'pbot_text_client', $twilio );
+
+		$twilio_client = $scheduler->get_text_client( $twilio );
+
+		$this->assertInstanceOf( Twilio::class, $twilio_client );
 		$this->assertConditionsMet();
 	}
 }


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/pending-order-bot/issues/1).

## Description / Background Context

At the moment we are currently utilising our SMS client (Twilio) inefficiently. We should be passing our SMS client via Dependency injection to enable us test accurately as well make our code easily refactorable. This PR refactors this piece of logic and updates unit tests accordingly.

## Testing Instructions

1. Pull PR to local.
2. Build plugin correctly: `composer install`.
3. Run tests: `composer run test`.
4. All tests should pass successfully like so:

<img width="378" alt="Screenshot 2025-02-16 at 14 59 24" src="https://github.com/user-attachments/assets/23073646-b619-40a4-82d6-b84ce42f250a" />