### PR TITLE
Chore: Improve Unit tests and Test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Pass Twilio client via Dependency Injection.
+* Improve Unit tests & Test coverage.
 
 ## 1.0.1
 * Restrict non-permited plugin files.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # pending-order-bot
 Send reminders on WooCommerce pending orders.
 
+[![Coverage Status](https://coveralls.io/repos/github/badasswp/pending-order-bot/badge.svg?branch=chore-improve-unit-tests-and-test-coverage)](https://coveralls.io/github/badasswp/pending-order-bot?branch=chore-improve-unit-tests-and-test-coverage)
+
 <img width="1342" alt="pending" src="https://github.com/user-attachments/assets/b1f2ca4f-1307-417e-a188-09037f2e76e3">
 
 ---

--- a/inc/Admin/Form.php
+++ b/inc/Admin/Form.php
@@ -18,7 +18,7 @@ class Form {
 	 *
 	 * @var mixed[]
 	 */
-	private array $options;
+	protected array $options;
 
 	/**
 	 * Set up Constructor.
@@ -112,7 +112,7 @@ class Form {
 		 * Pass in custom fields to the Admin Form with
 		 * key, value options.
 		 *
-		 * @since 1.0.0
+		 * @since 1.1.0
 		 *
 		 * @param mixed[] $fields Form Fields.
 		 * @return mixed[]

--- a/inc/Admin/Form.php
+++ b/inc/Admin/Form.php
@@ -112,7 +112,7 @@ class Form {
 		 * Pass in custom fields to the Admin Form with
 		 * key, value options.
 		 *
-		 * @since 1.1.0
+		 * @since 1.0.0
 		 *
 		 * @param mixed[] $fields Form Fields.
 		 * @return mixed[]

--- a/readme.txt
+++ b/readme.txt
@@ -45,6 +45,7 @@ Want to add your personal touch? All of our documentation can be found [here](ht
 
 = Unreleased =
 * Pass Twilio client via Dependency Injection.
+* Improve Unit tests & Test coverage.
 
 = 1.0.1 =
 * Restrict non-permited plugin files.

--- a/tests/Admin/FormTest.php
+++ b/tests/Admin/FormTest.php
@@ -1,0 +1,562 @@
+<?php
+
+namespace PendingOrderBot\Tests\Admin;
+
+use Mockery;
+use WP_Mock\Tools\TestCase;
+use PendingOrderBot\Admin\Form;
+
+/**
+ * @covers \PendingOrderBot\Admin\Form::__construct
+ * @covers \PendingOrderBot\Admin\Form::get_options
+ * @covers \PendingOrderBot\Admin\Form::get_form
+ * @covers \PendingOrderBot\Admin\Form::get_form_action
+ * @covers \PendingOrderBot\Admin\Form::get_form_main
+ * @covers \PendingOrderBot\Admin\Form::get_form_group
+ * @covers \PendingOrderBot\Admin\Form::get_form_group_body
+ * @covers \PendingOrderBot\Admin\Form::get_setting
+ * @covers \PendingOrderBot\Admin\Form::get_form_control
+ * @covers \PendingOrderBot\Admin\Form::get_text_control
+ * @covers \PendingOrderBot\Admin\Form::get_password_control
+ * @covers \PendingOrderBot\Admin\Form::get_checkbox_control
+ * @covers \PendingOrderBot\Admin\Form::get_select_control
+ * @covers \PendingOrderBot\Admin\Form::get_form_submit
+ * @covers \PendingOrderBot\Admin\Form::get_form_notice
+ */
+class FormTest extends TestCase {
+	public Form $form;
+
+	public function setUp(): void {
+		\WP_Mock::setUp();
+
+		$this->form = Mockery::mock( Form::class )->makePartial();
+		$this->form->shouldAllowMockingProtectedMethods();
+
+		$reflection = new \ReflectionClass( $this->form );
+		$property   = $reflection->getProperty( 'options' );
+		$property->setAccessible( true );
+		$property->setValue(
+			$this->form,
+			[
+				'page'   => [
+					'title'   => 'Plugin Title',
+					'summary' => 'Plugin Summary',
+					'slug'    => 'plugin-slug',
+					'option'  => 'plugin_option',
+				],
+				'fields' => [
+					[ 'form_group_1' ],
+					[ 'form_group_2' ],
+					[ 'form_group_3' ],
+				],
+				'submit' => [
+					'heading' => 'Plugin Title',
+					'button'  => [
+						'name'  => 'button_name',
+						'label' => 'Button Label',
+					],
+					'nonce'   => [
+						'name'   => 'nonce_name',
+						'action' => 'nonce_action',
+					],
+				],
+				'notice' => [
+					'label' => 'Notice Label',
+				],
+			]
+		);
+	}
+
+	public function tearDown(): void {
+		\WP_Mock::tearDown();
+	}
+
+	public function test_get_options() {
+		$this->form->shouldReceive( 'get_form' )
+			->andReturn( 'Plugin Form' );
+
+		$this->assertSame(
+			$this->form->get_options(),
+			[
+				'title'   => 'Plugin Title',
+				'summary' => 'Plugin Summary',
+				'form'    => 'Plugin Form',
+			]
+		);
+	}
+
+	public function test_get_form() {
+		$this->form->shouldReceive( 'get_form_action' )
+			->andReturn( 'https://example.com' );
+
+		$this->form->shouldReceive( 'get_form_notice' )
+			->andReturn( 'Form Notice' );
+
+		$this->form->shouldReceive( 'get_form_main' )
+			->andReturn( 'Form Main' );
+
+		$this->form->shouldReceive( 'get_form_submit' )
+			->andReturn( 'Form Submit' );
+
+		$plugin_form = $this->form->get_form();
+
+		$this->assertSame(
+			'<form class="badasswp-form" method="POST" action="https://example.com">
+				Form Notice
+				<div class="badasswp-form-main">Form Main</div>
+				<div class="badasswp-form-submit">Form Submit</div>
+			</form>',
+			$plugin_form
+		);
+	}
+
+	public function test_get_form_action() {
+		$_SERVER['REQUEST_URI'] = 'https://example.com/\/';
+
+		\WP_Mock::userFunction( 'esc_url' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return rtrim( filter_var( $arg, FILTER_SANITIZE_URL ), '/' );
+				}
+			);
+
+		\WP_Mock::userFunction( 'sanitize_text_field' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'wp_unslash' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return stripslashes( $arg );
+				}
+			);
+
+		$form_action = $this->form->get_form_action();
+
+		$this->assertSame( 'https://example.com', $form_action );
+	}
+
+	public function test_get_form_main() {
+		\WP_Mock::expectFilter(
+			'pbot_form_fields',
+			[
+				[ 'form_group_1' ],
+				[ 'form_group_2' ],
+				[ 'form_group_3' ],
+			]
+		);
+
+		$this->form->shouldReceive( 'get_form_group' )
+			->times( 3 )
+			->andReturnUsing(
+				function ( $arg ) {
+					return sprintf(
+						'<section>%s</section>',
+						json_encode( $arg )
+					);
+				}
+			);
+
+		$form_main = $this->form->get_form_main();
+
+		$this->assertSame(
+			'<section>["form_group_1"]</section><section>["form_group_2"]</section><section>["form_group_3"]</section>',
+			$form_main
+		);
+	}
+
+	public function test_get_form_group() {
+		$this->form->shouldReceive( 'get_form_group_body' )
+			->once()
+			->andReturn( 'Form Group Body' );
+
+		$form_group = $this->form->get_form_group(
+			[
+				'heading'  => 'Form Heading',
+				'controls' => [],
+			]
+		);
+
+		$this->assertSame(
+			'<div class="badasswp-form-group"><div class="badasswp-form-group-heading">Form Heading</div><div class="badasswp-form-group-body">Form Group Body</div></div>',
+			$form_group
+		);
+	}
+
+	public function test_get_form_group_body() {
+		$this->form->shouldReceive( 'get_form_control' )
+			->times( 1 )
+			->with(
+				[
+					'control'     => 'text',
+					'placeholder' => 'Placeholder',
+					'label'       => 'Label',
+					'summary'     => 'Summary',
+				],
+				'name'
+			)
+			->andReturn( 'Form Control' );
+
+		$form_group_body = $this->form->get_form_group_body(
+			[
+				'name' => [
+					'control'     => 'text',
+					'placeholder' => 'Placeholder',
+					'label'       => 'Label',
+					'summary'     => 'Summary',
+				],
+			]
+		);
+
+		$this->assertSame(
+			'<p class="badasswp-form-group-block">
+					<label>Label</label>
+					Form Control
+					<em>Summary</em>
+				</p>',
+			$form_group_body
+		);
+	}
+
+	public function test_get_setting() {
+		\WP_Mock::userFunction( 'get_option' )
+			->with( 'plugin_option', [] )
+			->andReturn(
+				[
+					'option_1' => 'Option 1',
+					'option_2' => 'Option 2',
+					'option_3' => 'Option 3',
+				]
+			);
+
+		$this->assertSame( 'Option 1', $this->form->get_setting( 'option_1' ) );
+		$this->assertSame( 'Option 2', $this->form->get_setting( 'option_2' ) );
+		$this->assertSame( 'Option 3', $this->form->get_setting( 'option_3' ) );
+	}
+
+	public function test_get_form_control_returns_text_control() {
+		$this->form->shouldReceive( 'get_text_control' )
+			->once()
+			->with(
+				[
+					'control'     => 'text',
+					'placeholder' => 'Text Placeholder',
+					'label'       => 'Text Label',
+					'summary'     => 'Text Summary',
+				],
+				'text_name'
+			)
+			->andReturn( 'Text Control' );
+
+		$control = $this->form->get_form_control(
+			[
+				'control'     => 'text',
+				'placeholder' => 'Text Placeholder',
+				'label'       => 'Text Label',
+				'summary'     => 'Text Summary',
+			],
+			'text_name'
+		);
+
+		$this->assertSame( 'Text Control', $control );
+	}
+
+	public function test_get_form_control_returns_password_control() {
+		$this->form->shouldReceive( 'get_password_control' )
+			->once()
+			->with(
+				[
+					'control'     => 'password',
+					'placeholder' => 'Password Placeholder',
+					'label'       => 'Password Label',
+					'summary'     => 'Password Summary',
+				],
+				'password_name'
+			)
+			->andReturn( 'Password Control' );
+
+		$control = $this->form->get_form_control(
+			[
+				'control'     => 'password',
+				'placeholder' => 'Password Placeholder',
+				'label'       => 'Password Label',
+				'summary'     => 'Password Summary',
+			],
+			'password_name'
+		);
+
+		$this->assertSame( 'Password Control', $control );
+	}
+
+	public function test_get_form_control_returns_select_control() {
+		$this->form->shouldReceive( 'get_select_control' )
+			->once()
+			->with(
+				[
+					'control'     => 'select',
+					'placeholder' => 'Select Placeholder',
+					'label'       => 'Select Label',
+					'summary'     => 'Select Summary',
+				],
+				'select_name'
+			)
+			->andReturn( 'Select Control' );
+
+		$control = $this->form->get_form_control(
+			[
+				'control'     => 'select',
+				'placeholder' => 'Select Placeholder',
+				'label'       => 'Select Label',
+				'summary'     => 'Select Summary',
+			],
+			'select_name'
+		);
+
+		$this->assertSame( 'Select Control', $control );
+	}
+
+	public function test_get_form_control_returns_checkbox_control() {
+		$this->form->shouldReceive( 'get_checkbox_control' )
+			->once()
+			->with(
+				[
+					'control'     => 'checkbox',
+					'placeholder' => 'Checkbox Placeholder',
+					'label'       => 'Checkbox Label',
+					'summary'     => 'Checkbox Summary',
+				],
+				'checkbox_name'
+			)
+			->andReturn( 'Checkbox Control' );
+
+		$control = $this->form->get_form_control(
+			[
+				'control'     => 'checkbox',
+				'placeholder' => 'Checkbox Placeholder',
+				'label'       => 'Checkbox Label',
+				'summary'     => 'Checkbox Summary',
+			],
+			'checkbox_name'
+		);
+
+		$this->assertSame( 'Checkbox Control', $control );
+	}
+
+	public function test_get_text_control() {
+		$this->form->shouldReceive( 'get_setting' )
+			->times( 1 )->with( 'text_name' )->andReturn( 'Text Name' );
+
+		$control = $this->form->get_text_control(
+			[
+				'control'     => 'text',
+				'placeholder' => 'Text Placeholder',
+				'label'       => 'Text Label',
+				'summary'     => 'Text Summary',
+			],
+			'text_name'
+		);
+
+		$this->assertSame(
+			'<input type="text" placeholder="Text Placeholder" value="Text Name" name="text_name"/>',
+			$control
+		);
+	}
+
+	public function test_get_password_control() {
+		$this->form->shouldReceive( 'get_setting' )
+			->times( 1 )->with( 'text_name' )->andReturn( 'Text Name' );
+
+		$control = $this->form->get_password_control(
+			[
+				'control'     => 'text',
+				'placeholder' => 'Text Placeholder',
+				'label'       => 'Text Label',
+				'summary'     => 'Text Summary',
+			],
+			'text_name'
+		);
+
+		$this->assertSame(
+			'<input type="password" placeholder="Text Placeholder" value="Text Name" name="text_name"/>',
+			$control
+		);
+	}
+
+	public function test_get_checkbox_control() {
+		$this->form->shouldReceive( 'get_setting' )
+			->times( 1 )->with( 'checkbox_name' )->andReturn( 'on' );
+
+		$control = $this->form->get_checkbox_control(
+			[
+				'control'     => 'checkbox',
+				'placeholder' => 'Checkbox Placeholder',
+				'label'       => 'Checkbox Label',
+				'summary'     => 'Checkbox Summary',
+			],
+			'checkbox_name'
+		);
+
+		$this->assertSame(
+			'<input
+				name="checkbox_name"
+				type="checkbox"
+				checked
+			/>',
+			$control
+		);
+	}
+
+	public function test_get_select_control() {
+		$this->form->shouldReceive( 'get_setting' )
+			->times( 4 )->with( 'select_name' )->andReturn( 'selected_option' );
+
+		$control = $this->form->get_select_control(
+			[
+				'control'     => 'select',
+				'placeholder' => 'Select Placeholder',
+				'label'       => 'Select Label',
+				'summary'     => 'Select Summary',
+				'options'     => [
+					'not_selected_option_1' => 'Not Selected Option 1',
+					'not_selected_option_2' => 'Not Selected Option 2',
+					'selected_option'       => 'Selected Option',
+					'not_selected_option_3' => 'Not Selected Option 3',
+				],
+			],
+			'select_name'
+		);
+
+		$this->assertSame(
+			'<select name="select_name">
+				<option value="not_selected_option_1" >Not Selected Option 1</option><option value="not_selected_option_2" >Not Selected Option 2</option><option value="selected_option" selected>Selected Option</option><option value="not_selected_option_3" >Not Selected Option 3</option>
+			</select>',
+			$control
+		);
+	}
+
+	public function test_get_form_submit() {
+		\WP_Mock::userFunction( 'wp_nonce_field' )
+			->with( 'nonce_action', 'nonce_name', true, false )
+			->andReturn( '<input type="hidden" id="nonce_name" name="nonce_name" value="a8gkfhvzhi" />' );
+
+		$form_submit = $this->form->get_form_submit();
+
+		$this->assertSame(
+			'<div class="badasswp-form-group">
+				<p class="badasswp-form-group-heading">
+					<strong>Plugin Title</strong>
+				</p>
+				<p class="badasswp-form-group-heading">
+					<button name="button_name" type="submit" class="button button-primary">
+						<span>Button Label</span>
+					</button>
+				</p>
+				<input type="hidden" id="nonce_name" name="nonce_name" value="a8gkfhvzhi" />
+			</div>',
+			$form_submit
+		);
+	}
+
+	public function test_get_form_notice_bails_out_if_button_name_is_not_set() {
+		$_POST['nonce_name'] = 'nonce_action\/';
+
+		\WP_Mock::userFunction( 'wp_unslash' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return rtrim( stripslashes( $arg ), '/' );
+				}
+			);
+
+		\WP_Mock::userFunction( 'sanitize_text_field' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'wp_verify_nonce' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1 === $arg2;
+				}
+			);
+
+		$form_notice = $this->form->get_form_notice();
+
+		$this->assertSame(
+			'',
+			$form_notice
+		);
+	}
+
+	public function test_get_form_notice_bails_out_if_wp_verify_nonce_fails() {
+		$_POST['button_name'] = true;
+		$_POST['nonce_name']  = 'incorrect_action_name\/';
+
+		\WP_Mock::userFunction( 'wp_unslash' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return rtrim( stripslashes( $arg ), '/' );
+				}
+			);
+
+		\WP_Mock::userFunction( 'sanitize_text_field' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'wp_verify_nonce' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1 === $arg2;
+				}
+			);
+
+		$form_notice = $this->form->get_form_notice();
+
+		$this->assertSame(
+			'',
+			$form_notice
+		);
+	}
+
+	public function test_get_form_notice_passes() {
+		$_POST['button_name'] = true;
+		$_POST['nonce_name']  = 'nonce_action\/';
+
+		\WP_Mock::userFunction( 'wp_unslash' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return rtrim( stripslashes( $arg ), '/' );
+				}
+			);
+
+		\WP_Mock::userFunction( 'sanitize_text_field' )
+			->andReturnUsing(
+				function ( $arg ) {
+					return $arg;
+				}
+			);
+
+		\WP_Mock::userFunction( 'wp_verify_nonce' )
+			->andReturnUsing(
+				function ( $arg1, $arg2 ) {
+					return $arg1 === $arg2;
+				}
+			);
+
+		$form_notice = $this->form->get_form_notice();
+
+		$this->assertSame(
+			'<div class="badasswp-form-notice">
+					<span>Notice Label</span>
+				</div>',
+			$form_notice
+		);
+	}
+}

--- a/tests/Admin/OptionsTest.php
+++ b/tests/Admin/OptionsTest.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace PendingOrderBot\Tests\Admin;
+
+use Mockery;
+use WP_Mock\Tools\TestCase;
+use PendingOrderBot\Admin\Options;
+
+/**
+ * @covers \PendingOrderBot\Admin\Options::get_form_page
+ * @covers \PendingOrderBot\Admin\Options::get_form_submit
+ * @covers \PendingOrderBot\Admin\Options::get_form_notice
+ * @covers \PendingOrderBot\Admin\Options::get_form_fields
+ */
+class OptionsTest extends TestCase {
+	public function setUp(): void {
+		\WP_Mock::setUp();
+	}
+
+	public function tearDown(): void {
+		\WP_Mock::tearDown();
+	}
+
+	public function test_get_form_page() {
+		\WP_Mock::userFunction(
+			'esc_html__',
+			[
+				'times'  => 2,
+				'return' => function ( $text, $domain = 'pending-order-bot' ) {
+					return $text;
+				},
+			]
+		);
+
+		$form_page = Options::get_form_page();
+
+		$this->assertSame(
+			$form_page,
+			[
+				'title'   => 'Pending Order Bot',
+				'summary' => 'Send reminders on WooCommerce pending orders.',
+				'slug'    => 'pending-order-bot',
+				'option'  => 'pending_order_bot',
+			]
+		);
+	}
+
+	public function test_get_form_submit() {
+		\WP_Mock::userFunction(
+			'esc_html__',
+			[
+				'times'  => 2,
+				'return' => function ( $text, $domain = 'pending-order-bot' ) {
+					return $text;
+				},
+			]
+		);
+
+		$form_submit = Options::get_form_submit();
+
+		$this->assertSame(
+			$form_submit,
+			[
+				'heading' => 'Actions',
+				'button'  => [
+					'name'  => 'pending_order_bot_save_settings',
+					'label' => 'Save Changes',
+				],
+				'nonce'   => [
+					'name'   => 'pending_order_bot_settings_nonce',
+					'action' => 'pending_order_bot_settings_action',
+				],
+			]
+		);
+	}
+
+	public function test_get_form_fields() {
+		\WP_Mock::userFunction(
+			'esc_html__',
+			[
+				'return' => function ( $text, $domain = 'pending-order-bot' ) {
+					return $text;
+				},
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'esc_attr',
+			[
+				'return' => function ( $text, $domain = 'pending-order-bot' ) {
+					return $text;
+				},
+			]
+		);
+
+		\WP_Mock::userFunction(
+			'esc_attr__',
+			[
+				'return' => function ( $text, $domain = 'pending-order-bot' ) {
+					return $text;
+				},
+			]
+		);
+
+		$form_fields = Options::get_form_fields();
+
+		$this->assertSame(
+			$form_fields,
+			[
+				'general_options' => [
+					'heading'  => 'General Options',
+					'controls' => [
+						'send_text'  => [
+							'control' => 'checkbox',
+							'label'   => 'Send Text',
+							'summary' => 'Use Twilio to send phone text messages.',
+						],
+						'send_email' => [
+							'control' => 'checkbox',
+							'label'   => 'Send E-mail',
+							'summary' => 'Use WP default e-mail address to send emails.',
+						],
+					],
+				],
+				'twilio_options'  => [
+					'heading'  => 'Twilio Options',
+					'controls' => [
+						'twilio_sid'     => [
+							'control'     => 'text',
+							'placeholder' => '',
+							'label'       => 'Account SID',
+							'summary'     => 'Twilio SID Number',
+						],
+						'twilio_token'   => [
+							'control'     => 'password',
+							'placeholder' => '',
+							'label'       => 'API Token',
+							'summary'     => 'Twilio API Token string',
+						],
+						'twilio_phone'   => [
+							'control'     => 'text',
+							'placeholder' => '',
+							'label'       => 'Phone Number',
+							'summary'     => 'e.g. +1234567890',
+						],
+						'twilio_message' => [
+							'control'     => 'text',
+							'placeholder' => '',
+							'label'       => 'Message',
+							'summary'     => 'e.g. You have abandoned orders.',
+						],
+					],
+				],
+			]
+		);
+	}
+
+	public function test_get_form_notice() {
+		\WP_Mock::userFunction(
+			'esc_html__',
+			[
+				'times'  => 1,
+				'return' => function ( $text, $domain = 'pending-order-bot' ) {
+					return $text;
+				},
+			]
+		);
+
+		$form_notice = Options::get_form_notice();
+
+		$this->assertSame(
+			$form_notice,
+			[
+				'label' => 'Settings Saved.',
+			]
+		);
+	}
+}

--- a/tests/Core/ContainerTest.php
+++ b/tests/Core/ContainerTest.php
@@ -5,13 +5,19 @@ namespace PendingOrderBot\Tests\Core;
 use Mockery;
 use WP_Mock\Tools\TestCase;
 
+use PendingOrderBot\Services\Boot;
 use PendingOrderBot\Core\Container;
 use PendingOrderBot\Services\Admin;
-use PendingOrderBot\Services\Boot;
+use PendingOrderBot\Abstracts\Service;
 use PendingOrderBot\Services\Scheduler;
 
 /**
+ * @covers \PendingOrderBot\Abstracts\Service::get_instance
  * @covers \PendingOrderBot\Core\Container::__construct
+ * @covers \PendingOrderBot\Core\Container::register
+ * @covers \PendingOrderBot\Services\Admin::register
+ * @covers \PendingOrderBot\Services\Boot::register
+ * @covers \PendingOrderBot\Services\Scheduler::register
  */
 class ContainerTest extends TestCase {
 	public Container $container;
@@ -30,5 +36,79 @@ class ContainerTest extends TestCase {
 		$this->assertTrue( in_array( Admin::class, Container::$services, true ) );
 		$this->assertTrue( in_array( Boot::class, Container::$services, true ) );
 		$this->assertTrue( in_array( Scheduler::class, Container::$services, true ) );
+	}
+
+	public function test_register() {
+		$container = new Container();
+
+		/**
+		 * Hack around unset Service::$instances.
+		 *
+		 * We create instances of services so we can
+		 * have a populated version of the Service abstraction's instances.
+		 */
+		foreach ( Container::$services as $service ) {
+			$service::get_instance();
+		}
+
+		\WP_Mock::expectActionAdded(
+			'admin_init',
+			[
+				Service::$services[ Admin::class ],
+				'register_options_init',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'admin_menu',
+			[
+				Service::$services[ Admin::class ],
+				'register_options_menu',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'admin_enqueue_scripts',
+			[
+				Service::$services[ Admin::class ],
+				'register_options_styles',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'init',
+			[
+				Service::$services[ Boot::class ],
+				'register_translation',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'wp_loaded',
+			[
+				Service::$services[ Scheduler::class ],
+				'schedule_reminders',
+			]
+		);
+
+		\WP_Mock::expectActionAdded(
+			'pending_orders',
+			[
+				Service::$services[ Scheduler::class ],
+				'send_reminders',
+			]
+		);
+
+		\WP_Mock::expectFilterAdded(
+			'cron_schedules',
+			[
+				Service::$services[ Scheduler::class ],
+				'register_cron_schedules',
+			]
+		);
+
+		$container->register();
+
+		$this->assertConditionsMet();
 	}
 }


### PR DESCRIPTION
This PR resolves this [issue](https://github.com/badasswp/pending-order-bot/issues/2).

## Description / Background Context

We need to update our unit tests to improve code coverage across the plugin. This PR implements this correctly.

## Testing Instructions

1. Pull PR to local.
2. Build plugin correctly: `composer install`.
3. Run tests: `composer run test`.
4. All tests should pass successfully like so:

<img width="363" alt="Screenshot 2025-02-16 at 20 21 10" src="https://github.com/user-attachments/assets/ec001fbb-87b6-4828-83b8-c0c792df1210" />